### PR TITLE
GeForce Game Ready Driver 378.78

### DIFF
--- a/geforce-game-ready-driver/geforce-game-ready-driver.nuspec
+++ b/geforce-game-ready-driver/geforce-game-ready-driver.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
 	<metadata>
 		<id>
-			geforce-game-ready-driver-win10
+			geforce-game-ready-driver
 		</id>
 		<title>
-			Geforce Game Ready Driver for Windows 10
+			Geforce Game Ready Driver
 		</title>
 		<version>
-			378.66
+			378.78
 		</version>
 		<authors>
 			NVIDIA
@@ -21,12 +21,12 @@
 		</summary>
 		<description>
 			GeForce Game Ready Driver
-			
+
 			This GeForce Game Ready driver ensures you'll have the best possible gaming experience. With support for GeForce SLI technology and one-click game setting optimizations within GeForce Experience, you'll have the best possible performance and image quality during gameplay.
-			
+
 			Game Ready
 			Best gaming experience, including support for SLI Technology and GeForce Experience 1-click optimizations
-			
+
 			Supported:
 			GeForce 10 Series
 			NVIDIA TITAN X (Pascal), GeForce GTX 1080, GeForce GTX 1070, GeForce GTX 1060
@@ -40,7 +40,7 @@
 			GeForce GTX 590, GeForce GTX 580, GeForce GTX 570, GeForce GTX 560 Ti, GeForce GTX 560 SE, GeForce GTX 560, GeForce GTX 555, GeForce GTX 550 Ti, GeForce GT 545, GeForce GT 530, GeForce GT 520, GeForce 510
 			GeForce 400 Series
 			GeForce GTX 480, GeForce GTX 470, GeForce GTX 465, GeForce GTX 460 SE v2, GeForce GTX 460 SE, GeForce GTX 460, GeForce GTS 450, GeForce GT 440, GeForce GT 430, GeForce GT 420
-			
+
 			If your GPU is not supported, try this:
 			https://chocolatey.org/packages/geforce-driver
 		</description>

--- a/geforce-game-ready-driver/tools/chocolateyinstall.ps1
+++ b/geforce-game-ready-driver/tools/chocolateyinstall.ps1
@@ -4,21 +4,29 @@ $workDirectory = New-Item (Join-Path ${ENV:TEMP} "nvidiadriver") -ItemType Direc
 $packageArgs = @{
     packageName   = $env:chocolateyPackageName
     url = "http://us.download.nvidia.com/Windows/$env:chocolateyPackageVersion/$env:chocolateyPackageVersion-desktop-win10-32bit-international-whql.exe"
-    checksum      = 'ea988083e3b43cbcbcef54ad29b6d8d2c4f625460de41292c48661354837e6f0'
-    checksumType  = 'sha256'
+    checksum      = '34f6edbfca3cbe70dc83589bfae339437658b2b8c291a9fc278aee0c7cabf6d495ebfb64dff8da3dc6966409ce2857a911c6a39d489c3c6b9fb5597075e04361'
+    checksumType  = 'sha512'
 
     url64bit = "http://us.download.nvidia.com/Windows/$env:chocolateyPackageVersion/$env:chocolateyPackageVersion-desktop-win10-64bit-international-whql.exe"
-    checksum64    = 'ddf2e726eefd1e5cdaba31ec023c075df282685377652c1bdd343be1b1792b9cc393f0eed50b0ebc31b37bd651470f86a908de559c3969ea7472e5b0045ac12c'
+    checksum64    = '753e7023b6ea7dd451cc1ac639d838f6f137a4153e88d6051d8217d69be631f007e90c3a672e795e31abf8a930927a7376eeca7da5852c4cf8de522f51a0fc73'
     checksumType64= 'sha512'
 
-    silentArgs = "-s -noreboot -clean" 
+    silentArgs = "-s -noreboot -clean"
+}
+
+# override to use the non-Windows 10 versions
+If ( [System.Environment]::OSVersion.Version.Major -ne '10' ) {
+	$packageArgs.url   = "http://us.download.nvidia.com/Windows/$env:chocolateyPackageVersion/$env:chocolateyPackageVersion-desktop-win8-win7-32bit-international-whql.exe"
+	$packageArgs.url64 = "http://us.download.nvidia.com/Windows/$env:chocolateyPackageVersion/$env:chocolateyPackageVersion-desktop-win8-win7-64bit-international-whql.exe"
+	$packageArgs.checksum   = '2f81b0778d65436708369c3283ca37fa72825eb12c512c22e92362efbf47fa0a17b4d7c86bba289b12007c5c781b33e8a9d1ae891c62c8b2a7913272ffcdd46f'
+	$packageArgs.checksum64 = 'd1883e733fa15ba43b76475cb9829bc8fb5edc2fb7efed49e24b3fc206b474f209f0a6b49f4e22a197c3b3c1f0e3f959b2649b394fdf0d6d4e68dafd0d4a8f00'
 }
 
 # TODO make this part driven by parameters to enable or disable components should people want GEForce Experience or 3DVision
 $deselectedPatterns = @(
-    "NV3DVision*", 
+    "NV3DVision*",
     "GFExperience*",
-    "Display.NView", 
+    "Display.NView",
     "Display.Update")
 
 Get-ChocolateyWebFile @packageArgs -FileFullPath $installerFile


### PR DESCRIPTION
Supports Windows 7, 8 and 10.  The -win10 version is replaced with this
one.